### PR TITLE
Lazy fix for crate collision

### DIFF
--- a/code/Crates/Crate.cs
+++ b/code/Crates/Crate.cs
@@ -48,7 +48,7 @@ namespace Grubs.Crates
 		private void Move()
 		{
 			var mover = new MoveHelper( Position, Velocity );
-			mover.Trace = mover.Trace.Size( BBox ).Ignore( this ).WorldOnly();
+			mover.Trace = mover.Trace.Size( BBox ).Ignore( this );
 			GroundEntity = mover.TraceDirection( Vector3.Down ).Entity;
 
 			if ( GroundEntity == null )


### PR DESCRIPTION
Mostly temporary just so crates will actually land in the terrain.

Tested on my terrain implementation fork.

Possible bugs: Crate will stop when it touches a person as well as terrain.