### PR TITLE
Fix aimclamp angle being inverted when changing facing, fix snap angle being wrong during change 

### DIFF
--- a/code/Player/Grub/Grub.Input.cs
+++ b/code/Player/Grub/Grub.Input.cs
@@ -46,8 +46,10 @@ public partial class Grub
 
 	public void UpdateInputFromOwner( float moveInput, float lookInput )
 	{
+		var nextFacing = Rotation.z < 0 ? -1 : 1;
+
 		MoveInput = moveInput;
-		LookInput = -Facing * lookInput;
+		LookInput = -nextFacing * lookInput;
 
 		if ( ActiveWeapon.IsValid() && ActiveWeapon.IsCharging() )
 			return;
@@ -80,13 +82,14 @@ public partial class Grub
 				ChangedSnapAngle = false;
 			}
 
-			SnappedLookAngle = MathX.Clamp( SnappedLookAngle, -45f, 45f );
+			if ( nextFacing != LastFacing )
+				SnappedLookAngle = -SnappedLookAngle.Clamp( -45f, 45f );
+			else
+				SnappedLookAngle = SnappedLookAngle.Clamp( -45f, 45f );
 		}
 
-		if ( Facing != LastFacing )
+		if ( nextFacing != LastFacing )
 			LookAngles = LookAngles.WithPitch( LookAngles.pitch * -1 );
-
-		LastFacing = Facing;
 
 		if ( Debug && IsTurn )
 		{
@@ -98,6 +101,8 @@ public partial class Grub
 			var tr = Trace.Ray( AimRay, 80f ).Run();
 			DebugOverlay.TraceResult( tr );
 		}
+
+		LastFacing = nextFacing;
 	}
 
 	[ConVar.Replicated( "gr_debug_input" )]

--- a/code/Player/Grub/Grub.Input.cs
+++ b/code/Player/Grub/Grub.Input.cs
@@ -91,6 +91,8 @@ public partial class Grub
 		if ( nextFacing != LastFacing )
 			LookAngles = LookAngles.WithPitch( LookAngles.pitch * -1 );
 
+		LastFacing = nextFacing;
+
 		if ( Debug && IsTurn )
 		{
 			DebugOverlay.ScreenText( $"MoveInput: {MoveInput}", 13 );
@@ -101,8 +103,6 @@ public partial class Grub
 			var tr = Trace.Ray( AimRay, 80f ).Run();
 			DebugOverlay.TraceResult( tr );
 		}
-
-		LastFacing = nextFacing;
 	}
 
 	[ConVar.Replicated( "gr_debug_input" )]


### PR DESCRIPTION
Closes:https://github.com/apetavern/sbox-grubs/issues/218

Before, the angle was inverted when you changed directions. Also, the new angle would be wrong for a few frames after the change in direction. Sometimes right on the first frame and then wrong for the next 3-4 frames, and then right again. This fixes both of those problems. Some problem with using Facing directly, so we just calculate it again in the function scope. 

https://user-images.githubusercontent.com/66768086/235410720-6e3192b7-aa6f-428f-96a7-5b85efb317b3.mp4


