### PR TITLE
Geometry added with AddTexture is now centered

### DIFF
--- a/code/Terrain/Terrain.Modifications.cs
+++ b/code/Terrain/Terrain.Modifications.cs
@@ -63,7 +63,9 @@ public partial class Terrain
 	public void AddTexture( Texture texture, int gradientWidth, float worldWidth, Vector2 position, Rotation2D rotation, Dictionary<Sdf2DMaterial, float> materials )
 	{
 		var textureSdf = new TextureSdf( texture, gradientWidth, worldWidth );
-		var transformedTextureSdf = textureSdf.Transform( position, rotation );
+		var transformedTextureSdf = textureSdf
+			.Translate( textureSdf.Bounds.Size * -0.5f )
+			.Transform( position, rotation );
 		foreach ( var (material, offset) in materials )
 			Add( SdfWorld, transformedTextureSdf.Expand( offset ), material );
 	}


### PR DESCRIPTION
Fixes #240 by offsetting the TextureSdf by half the size.

Alternatively, I can make it so that TextureSdf is always centered in facepunch.libsdf, if you think that should be the default behaviour. This would mean you'd need to tweak the terrain loading code.