### PR TITLE
NameTag health transition

### DIFF
--- a/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
+++ b/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
@@ -11,14 +11,32 @@
         <img src="avatar:@Grub.Player.SteamId" class="avatar @DisplayAvatar()" />
     }
     <text>@Grub.Name</text>
-    <text>@((int)Grub.Health)</text>
+    <text>@((int)_health)</text>
 </root>
 
 @code {
     public Grub Grub => Entity as Grub;
     public Player LocalPlayer => Game.LocalPawn as Player;
 
-    public GrubWorldPanel(Grub grub) : base(grub) { }
+    private float _health;
+    private const float _transitionRate = 35f;
+
+    public GrubWorldPanel(Grub grub) : base(grub)
+    {
+        _health = Grub.Health;
+    }
+
+    public override void Tick()
+    {
+        base.Tick();
+
+        if (_health != Grub.Health)
+        {
+            int delta = Grub.Health < _health ? -1 : 1; // Is health decreasing or increasing?
+            float health = _health + (delta * Time.Delta * _transitionRate);
+            _health = health.Clamp(Math.Min(_health, Grub.Health), Math.Max(_health, Grub.Health)); // Ensure we don't overshoot.
+        }
+    }
 
     string DisplayAvatar()
     {
@@ -29,7 +47,7 @@
 
     protected override int BuildHash()
     {
-        return HashCode.Combine(Grub?.Name, Grub?.Health, LocalPlayer?.GrubsCamera?.Distance);
+        return HashCode.Combine(Grub?.Name, _health, LocalPlayer?.GrubsCamera?.Distance);
     }
 }
 

--- a/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
+++ b/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
@@ -11,7 +11,7 @@
         <img src="avatar:@Grub.Player.SteamId" class="avatar @DisplayAvatar()" />
     }
     <text>@Grub.Name</text>
-    <text>@((int)_health)</text>
+    <text>@((int)MathF.Ceiling(_health))</text>
 </root>
 
 @code {


### PR DESCRIPTION
[#166](https://github.com/apetavern/sbox-grubs/issues/166)

The rate at which the health text transitions can be adjusted by the _transitionRate variable in GrubWorldPanel.razor. The health text transitions the same way when increasing (say, healing), however, this can be easily removed if unwanted.

I also set the NameTag health to always MathF.Ceiling(), whereas previously it would always floor due to int typecasting. While this is out of scope, I ran into a -5 damage number putting a Grub's NameTag health from 100 -> 94 (Grub.Health was at 94.988) while I was testing, and since I believe this to be unintentional and it was a one-line fix in the same file I figured what the heck.


https://github.com/apetavern/sbox-grubs/assets/43252311/42a7d632-aab9-4f1c-b8e3-08152bdd3fbd

