### PR TITLE
facepunch.libsdf API changes

### DIFF
--- a/code/Terrain/Terrain.Materials.cs
+++ b/code/Terrain/Terrain.Materials.cs
@@ -4,20 +4,20 @@ namespace Grubs;
 
 public partial class Terrain
 {
-	public Sdf2DMaterial DevMaterial { get; } = ResourceLibrary.Get<Sdf2DMaterial>( "materials/sdf2d_default.sdflayer" );
-	public Sdf2DMaterial SandMaterial { get; } = ResourceLibrary.Get<Sdf2DMaterial>( "materials/sdf/sand.sdflayer" );
-	public Sdf2DMaterial DirtMaterial { get; } = ResourceLibrary.Get<Sdf2DMaterial>( "materials/sdf/dirt.sdflayer" );
-	public Sdf2DMaterial RockMaterial { get; } = ResourceLibrary.Get<Sdf2DMaterial>( "materials/sdf/rock.sdflayer" );
+	public Sdf2DLayer DevMaterial { get; } = ResourceLibrary.Get<Sdf2DLayer>( "materials/sdf2d_default.sdflayer" );
+	public Sdf2DLayer SandMaterial { get; } = ResourceLibrary.Get<Sdf2DLayer>( "materials/sdf/sand.sdflayer" );
+	public Sdf2DLayer DirtMaterial { get; } = ResourceLibrary.Get<Sdf2DLayer>( "materials/sdf/dirt.sdflayer" );
+	public Sdf2DLayer RockMaterial { get; } = ResourceLibrary.Get<Sdf2DLayer>( "materials/sdf/rock.sdflayer" );
 
-	public Sdf2DMaterial GirderMaterial { get; } = ResourceLibrary.Get<Sdf2DMaterial>( "materials/sdf/girder.sdflayer" );
+	public Sdf2DLayer GirderMaterial { get; } = ResourceLibrary.Get<Sdf2DLayer>( "materials/sdf/girder.sdflayer" );
 
-	public Dictionary<Sdf2DMaterial, float> GetActiveMaterials( MaterialsConfig cfg )
+	public Dictionary<Sdf2DLayer, float> GetActiveMaterials( MaterialsConfig cfg )
 	{
-		var materials = new Dictionary<Sdf2DMaterial, float>();
+		var materials = new Dictionary<Sdf2DLayer, float>();
 
 		var terrainType = GrubsConfig.WorldTerrainEnvironmentType;
 
-		List<Sdf2DMaterial> activeMaterials;
+		List<Sdf2DLayer> activeMaterials;
 
 		activeMaterials = terrainType switch
 		{
@@ -36,24 +36,24 @@ public partial class Terrain
 		return materials;
 	}
 
-	public List<Sdf2DMaterial> GetSandMaterials()
+	public List<Sdf2DLayer> GetSandMaterials()
 	{
-		return new List<Sdf2DMaterial>() { SandMaterial, RockMaterial };
+		return new List<Sdf2DLayer>() { SandMaterial, RockMaterial };
 	}
 
-	public List<Sdf2DMaterial> GetDirtMaterials()
+	public List<Sdf2DLayer> GetDirtMaterials()
 	{
-		return new List<Sdf2DMaterial>() { DirtMaterial, RockMaterial };
+		return new List<Sdf2DLayer>() { DirtMaterial, RockMaterial };
 	}
 
-	public List<Sdf2DMaterial> GetGirderMaterials()
+	public List<Sdf2DLayer> GetGirderMaterials()
 	{
-		return new List<Sdf2DMaterial>() { GirderMaterial };
+		return new List<Sdf2DLayer>() { GirderMaterial };
 	}
 
-	public List<Sdf2DMaterial> GetAllMaterials()
+	public List<Sdf2DLayer> GetAllMaterials()
 	{
-		return new List<Sdf2DMaterial>() { GirderMaterial };
+		return new List<Sdf2DLayer>() { GirderMaterial };
 	}
 }
 

--- a/code/Terrain/Terrain.Modifications.cs
+++ b/code/Terrain/Terrain.Modifications.cs
@@ -14,7 +14,7 @@ public partial class Terrain
 	/// <param name="radius">The radius of the subtraction.</param>
 	/// <param name="materials">The Sdf2dMaterials and offsets of the subtraction.</param>
 	/// <param name="worldOffset">Whether or not to use an offset from the Sdf to the world (for terrain generation).</param>
-	public void SubtractCircle( Vector2 center, float radius, Dictionary<Sdf2DMaterial, float> materials, bool worldOffset = false )
+	public void SubtractCircle( Vector2 center, float radius, Dictionary<Sdf2DLayer, float> materials, bool worldOffset = false )
 	{
 		var circleSdf = new CircleSdf( center, radius );
 		foreach ( var (material, offset) in materials )
@@ -29,7 +29,7 @@ public partial class Terrain
 	/// <param name="materials">The Sdf2dMaterials and offsets of the subtraction.</param>
 	/// <param name="cornerRadius">The corner radius of the box.</param>
 	/// <param name="worldOffset">Whether or not to use an offset from the Sdf to the world (for terrain generation).</param>
-	public void SubtractBox( Vector2 mins, Vector2 maxs, Dictionary<Sdf2DMaterial, float> materials, float cornerRadius = 0, bool worldOffset = false )
+	public void SubtractBox( Vector2 mins, Vector2 maxs, Dictionary<Sdf2DLayer, float> materials, float cornerRadius = 0, bool worldOffset = false )
 	{
 		var boxSdf = new BoxSdf( mins, maxs, cornerRadius );
 		foreach ( var (material, offset) in materials )
@@ -44,7 +44,7 @@ public partial class Terrain
 	/// <param name="radius">The radius of the line.</param>
 	/// <param name="materials">The Sdf2dMaterials and offsets of the subtraction.</param>
 	/// <param name="worldOffset">Whether or not to use an offset from the Sdf to the world (for terrain generation).</param>
-	public void SubtractLine( Vector2 start, Vector2 end, float radius, Dictionary<Sdf2DMaterial, float> materials, bool worldOffset = false )
+	public void SubtractLine( Vector2 start, Vector2 end, float radius, Dictionary<Sdf2DLayer, float> materials, bool worldOffset = false )
 	{
 		var lineSdf = new LineSdf( start, end, radius );
 		foreach ( var (material, offset) in materials )
@@ -60,7 +60,7 @@ public partial class Terrain
 	/// <param name="position">The position of the Sdf.</param>
 	/// <param name="rotation">The rotation of the Sdf.</param>
 	/// <param name="materials">The Sdf2dMaterials and offsets of the subtraction.</param>
-	public void AddTexture( Texture texture, int gradientWidth, float worldWidth, Vector2 position, Rotation2D rotation, Dictionary<Sdf2DMaterial, float> materials )
+	public void AddTexture( Texture texture, int gradientWidth, float worldWidth, Vector2 position, Rotation2D rotation, Dictionary<Sdf2DLayer, float> materials )
 	{
 		var textureSdf = new TextureSdf( texture, gradientWidth, worldWidth );
 		var transformedTextureSdf = textureSdf
@@ -77,7 +77,7 @@ public partial class Terrain
 	/// <param name="height">The height of the world.</param>
 	/// <param name="fgMaterial">The material for the foreground of the world.</param>
 	/// <param name="bgMaterial">The material for the background of the world.</param>
-	private void AddWorldBox( int length, int height, Sdf2DMaterial fgMaterial, Sdf2DMaterial bgMaterial )
+	private void AddWorldBox( int length, int height, Sdf2DLayer fgMaterial, Sdf2DLayer bgMaterial )
 	{
 		lengthOffset = length / 2;
 		heightOffset = 0;
@@ -93,7 +93,7 @@ public partial class Terrain
 	/// <param name="world">The world to subtract from.</param>
 	/// <param name="sdf">The Sdf to apply.</param>
 	/// <param name="material">The material to apply.</param>
-	private void Add( Sdf2DWorld world, ISdf2D sdf, Sdf2DMaterial material )
+	private void Add( Sdf2DWorld world, ISdf2D sdf, Sdf2DLayer material )
 	{
 		world.Add( sdf, material );
 	}
@@ -105,7 +105,7 @@ public partial class Terrain
 	/// <param name="sdf">The Sdf to apply.</param>
 	/// <param name="material">The material to apply.</param>
 	/// <param name="offset">Whether to apply the offset of the Sdf to world position.</param>
-	private void Subtract( Sdf2DWorld world, ISdf2D sdf, Sdf2DMaterial material, bool offset = false )
+	private void Subtract( Sdf2DWorld world, ISdf2D sdf, Sdf2DLayer material, bool offset = false )
 	{
 		if ( offset )
 			sdf = sdf.Translate( new Vector2( -lengthOffset, heightOffset ) );

--- a/code/Terrain/Terrain.Modifications.cs
+++ b/code/Terrain/Terrain.Modifications.cs
@@ -64,7 +64,6 @@ public partial class Terrain
 	{
 		var textureSdf = new TextureSdf( texture, gradientWidth, worldWidth );
 		var transformedTextureSdf = textureSdf
-			.Translate( textureSdf.Bounds.Size * -0.5f )
 			.Transform( position, rotation );
 		foreach ( var (material, offset) in materials )
 			Add( SdfWorld, transformedTextureSdf.Expand( offset ), material );

--- a/code/Terrain/Terrain.Texture.cs
+++ b/code/Terrain/Terrain.Texture.cs
@@ -19,7 +19,7 @@ public partial class Terrain
 		GrubsConfig.TerrainLength = mapSdfTexture.Width;
 		GrubsConfig.TerrainHeight = mapSdfTexture.Height;
 
-		var mapSdf = new TextureSdf( mapSdfTexture, 10, mapSdfTexture.Width * 2f );
+		var mapSdf = new TextureSdf( mapSdfTexture, 10, mapSdfTexture.Width * 2f, pivot: 0f );
 		var transformedSdf = mapSdf.Transform( new Vector2( -GrubsConfig.TerrainLength, 0 ) );
 
 		var cfg = new MaterialsConfig( true, true );
@@ -28,7 +28,7 @@ public partial class Terrain
 		SdfWorld.Add( transformedSdf, materials.ElementAt( 0 ).Key );
 
 		mapSdfTexture = await Texture.LoadAsync( FileSystem.Mounted, "textures/texturelevels/" + GrubsConfig.WorldTerrainTexture.ToString() + "_back.png" );
-		mapSdf = new TextureSdf( mapSdfTexture, 10, mapSdfTexture.Width * 2f );
+		mapSdf = new TextureSdf( mapSdfTexture, 10, mapSdfTexture.Width * 2f, pivot: 0f );
 		transformedSdf = mapSdf.Transform( new Vector2( -GrubsConfig.TerrainLength, 0 ) );
 
 		SdfWorld.Add( transformedSdf, materials.ElementAt( 1 ).Key );

--- a/code/Weapons/Components/BuildComponent.cs
+++ b/code/Weapons/Components/BuildComponent.cs
@@ -88,7 +88,7 @@ public partial class BuildComponent : WeaponComponent
 			var girderTexture = Texture.Load( FileSystem.Mounted, "textures/texturestamps/girder_sdf.png" );
 
 			var terrain = GamemodeSystem.Instance.Terrain;
-			var materials = new Dictionary<Sdf2DMaterial, float>();
+			var materials = new Dictionary<Sdf2DLayer, float>();
 			foreach ( var mat in terrain.GetGirderMaterials() )
 				materials.Add( mat, 0f );
 


### PR DESCRIPTION
* `Sdf2DMaterial` is now `Sdf2DLayer`
  * I'd recommend renaming variables / fields / properties storing instances of this type from `material` to `layer`, but I haven't done that here
* `TextureSdf` is now centered by default
  * I've updated the map loading code and girder placement accordingly
  * You can give an optional `pivot` parameter to choose the center, from `(0, 0)` (the old behaviour) to `(1, 1)`