### PR TITLE
Fix arc projectiles exploding prematurely

### DIFF
--- a/code/Weapons/ArcTrace.cs
+++ b/code/Weapons/ArcTrace.cs
@@ -11,7 +11,7 @@ public class ArcTrace
 {
 	public Vector3 StartPos { get; set; }
 	public Vector3 EndPos { get; set; }
-	private int SegmentCount { get; set; } = 80;
+	private int SegmentCount { get; set; } = 256;
 	private Grub Owner { get; set; }
 	private Gadget Gadget { get; set; }
 

--- a/code/Weapons/Gadget/Components/ArcPhysicsGadgetComponent.cs
+++ b/code/Weapons/Gadget/Components/ArcPhysicsGadgetComponent.cs
@@ -63,9 +63,13 @@ public partial class ArcPhysicsGadgetComponent : GadgetComponent
 			Gadget.Velocity = (currentSegment.EndPos - Gadget.Position) * ProjectileSpeed;
 			Gadget.Position = Vector3.Lerp( currentSegment.StartPos, currentSegment.EndPos, _alpha );
 		}
-		else
+		else if ( _explosiveComponent?.ExplodeAfter > 0 )
 		{
 			_explosiveComponent?.ExplodeAfterSeconds( _explosiveComponent.ExplodeAfter );
+		}
+		else
+		{
+			_explosiveComponent?.Explode();
 		}
 	}
 


### PR DESCRIPTION
Fixes:#264

I'm not really a huge fan of this fix to be honest. It's not a catch-all. It might be more ideal to not have a capped segment count in the first place. Maybe a time limit instead? Anyway, the segment count was really low and those grubs can really yeet projectiles, so it was going insanely high but the segment count wasn't large enough and the projectile exploded early. The `ArcPhysicsGadgetComponent` defaulted to exploding the projectile regardless of its `ExplodeAfter` time.