### PR TITLE
Fix a bug where the first player in the turn queue always gets immediately skipped on game start.

### DIFF
--- a/code/Gamemodes/Modes/FFA/FreeForAll.cs
+++ b/code/Gamemodes/Modes/FFA/FreeForAll.cs
@@ -47,7 +47,7 @@ public partial class FreeForAll : Gamemode
 	/// </summary>
 	private void SpawnPlayers()
 	{
-		foreach ( var client in Game.Clients.OrderByDescending( x => !x.IsBot ) )
+		foreach ( var client in Game.Clients.Shuffle().OrderByDescending( x => !x.IsBot ) )
 		{
 			if ( client.Pawn is not Player player )
 				continue;

--- a/code/Gamemodes/Modes/FFA/FreeForAll.cs
+++ b/code/Gamemodes/Modes/FFA/FreeForAll.cs
@@ -37,6 +37,7 @@ public partial class FreeForAll : Gamemode
 	{
 		SpawnPlayers();
 
+		TimeUntilNextTurn = GrubsConfig.TurnDuration;
 		CurrentState = State.Playing;
 	}
 
@@ -46,7 +47,7 @@ public partial class FreeForAll : Gamemode
 	/// </summary>
 	private void SpawnPlayers()
 	{
-		foreach ( var client in Game.Clients )
+		foreach ( var client in Game.Clients.OrderByDescending( x => !x.IsBot ) )
 		{
 			if ( client.Pawn is not Player player )
 				continue;

--- a/code/Utils/Extensions/IEnumerableExtensions.cs
+++ b/code/Utils/Extensions/IEnumerableExtensions.cs
@@ -23,4 +23,9 @@ public static class ListExtensions
 				list.RemoveAt( i );
 		}
 	}
+
+	public static IEnumerable<T> Shuffle<T>( this IEnumerable<T> list )
+	{
+		return list.OrderBy( x => Guid.NewGuid() );
+	}
 }


### PR DESCRIPTION
Also always prioritize players over bots in turn order. Good for developing and for players playing with bots alike.
https://cdn.discordapp.com/attachments/1078732315469029456/1111471817903837274/sbox_0016.mp4