### PR TITLE
fix: Enlarge GrubWorldPanel to fit at least 10 char names

### DIFF
--- a/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
+++ b/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
@@ -27,7 +27,6 @@
         _health = Grub.Health;
 
         // Enlarge the panel bounds to fit larger names.
-        // The default is ( -500, -500, 1000, 1000 )
         PanelBounds = new Rect( -1000, -1000, 2000, 2000 );
     }
 
@@ -50,7 +49,6 @@
 
     protected override int BuildHash()
     {
-        @* return HashCode.Combine(Grub?.Name, _health, LocalPlayer?.GrubsCamera?.Distance); *@
-        return HashCode.Combine(DateTime.Now.ToString());
+        return HashCode.Combine(Grub?.Name, _health, LocalPlayer?.GrubsCamera?.Distance);
     }
 }

--- a/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
+++ b/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor
@@ -25,6 +25,10 @@
     public GrubWorldPanel(Grub grub) : base(grub, Vector3.Up * 50f)
     {
         _health = Grub.Health;
+
+        // Enlarge the panel bounds to fit larger names.
+        // The default is ( -500, -500, 1000, 1000 )
+        PanelBounds = new Rect( -1000, -1000, 2000, 2000 );
     }
 
     public override void Tick()
@@ -46,6 +50,7 @@
 
     protected override int BuildHash()
     {
-        return HashCode.Combine(Grub?.Name, _health, LocalPlayer?.GrubsCamera?.Distance);
+        @* return HashCode.Combine(Grub?.Name, _health, LocalPlayer?.GrubsCamera?.Distance); *@
+        return HashCode.Combine(DateTime.Now.ToString());
     }
 }

--- a/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor.scss
+++ b/code/UI/World/EntityWorldPanel/GrubWorldPanel.razor.scss
@@ -29,7 +29,6 @@
         text-shadow: 2px 2px 2px black;
         text-stroke: 4px black;
         margin: 2px 0;
-        max-width: 500px;
         text-align: center;
     }
 


### PR DESCRIPTION
```gherkin
Given you input a 10 character grub name
  When you enter the game
  Then you should see the 10 character grub name on your grub
```

This PR extends the `PanelBounds` on the `GrubWorldPanel` to fit the largest grub name you can input in the menu. If you somehow have a large enough grub name that's beyond 10 characters then an ellipsis will show as normal.

before:

![image](https://github.com/apetavern/sbox-grubs/assets/17505288/a22fff9d-39e3-42ad-811f-271e06866e85)

after:

![image](https://github.com/apetavern/sbox-grubs/assets/17505288/fdcfc483-1227-4fed-b4a8-2940df4659c3)
